### PR TITLE
Fix: make GPT polling async

### DIFF
--- a/bot_main.py
+++ b/bot_main.py
@@ -40,7 +40,7 @@ async def ask_gpt_assistant(message: str) -> str:
             )
             if status.status == "completed":
                 break
-            time.sleep(1)
+            await asyncio.sleep(1)
         messages = openai.beta.threads.messages.list(thread_id=thread.id)
         for msg in reversed(messages.data):
             if msg.role == "assistant":


### PR DESCRIPTION
## Summary
- avoid blocking sleep when polling GPT status

## Testing
- `python -m py_compile bot_main.py`


------
https://chatgpt.com/codex/tasks/task_b_685b54788e78832c8a5ed4a6fa377d59